### PR TITLE
Mz 306/ 통계 수정사항 반영

### DIFF
--- a/data/src/main/java/com/susu/data/data/repository/StatisticsRepositoryImpl.kt
+++ b/data/src/main/java/com/susu/data/data/repository/StatisticsRepositoryImpl.kt
@@ -13,6 +13,7 @@ class StatisticsRepositoryImpl @Inject constructor(
 ) : StatisticsRepository {
     override suspend fun getMyStatistics(): MyStatistics {
         val originalStatistic = statisticsService.getMyStatistics().getOrThrow().toModel()
+        val visibleRecentSpentCount = if (originalStatistic.recentSpent.size > 6) 6 else originalStatistic.recentSpent.size
         val sortedRecentSpent = originalStatistic.recentSpent
             .filter {
                 currentYear == it.title.substring(0 until 4).toInt()
@@ -24,6 +25,7 @@ class StatisticsRepositoryImpl @Inject constructor(
                 )
             }
             .sortedBy { it.title.toInt() }
+            .takeLast(visibleRecentSpentCount)
 
         return MyStatistics(
             highestAmountReceived = originalStatistic.highestAmountReceived,
@@ -43,6 +45,8 @@ class StatisticsRepositoryImpl @Inject constructor(
             relationshipId = relationshipId,
             categoryId = categoryId,
         ).getOrThrow().toModel()
+
+        val visibleRecentSpentCount = if (originalStatistic.recentSpent.size > 6) 6 else originalStatistic.recentSpent.size
         val sortedRecentSpent = originalStatistic.recentSpent
             .filter {
                 currentYear == it.title.substring(0 until 4).toInt()
@@ -54,6 +58,7 @@ class StatisticsRepositoryImpl @Inject constructor(
                 )
             }
             .sortedBy { it.title.toInt() }
+            .takeLast(visibleRecentSpentCount)
 
         return SusuStatistics(
             averageSent = originalStatistic.averageSent,

--- a/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
+++ b/feature/navigator/src/main/java/com/susu/feature/navigator/MainScreen.kt
@@ -202,6 +202,7 @@ internal fun MainScreen(
                     navigateToMyInfo = navigator::navigateMyPageInfo,
                     navigateToSent = navigator::navigateSent,
                     onShowDialog = viewModel::onShowDialog,
+                    onShowSnackbar = viewModel::onShowSnackbar,
                     handleException = viewModel::handleException,
                 )
 

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/StatisticsScreen.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/StatisticsScreen.kt
@@ -25,6 +25,7 @@ import com.susu.core.designsystem.component.appbar.icon.LogoIcon
 import com.susu.core.designsystem.component.screen.LoadingScreen
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.DialogToken
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.statistics.component.StatisticsTab
 import com.susu.feature.statistics.content.my.MyStatisticsRoute
@@ -37,6 +38,7 @@ fun StatisticsRoute(
     navigateToMyInfo: () -> Unit,
     navigateToSent: () -> Unit,
     onShowDialog: (DialogToken) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -64,6 +66,7 @@ fun StatisticsRoute(
         navigateToMyInfo = navigateToMyInfo,
         navigateToSent = navigateToSent,
         onShowDialog = onShowDialog,
+        onShowSnackbar = onShowSnackbar,
         handleException = handleException,
     )
 }
@@ -76,6 +79,7 @@ fun StatisticsScreen(
     navigateToMyInfo: () -> Unit = {},
     navigateToSent: () -> Unit = {},
     onShowDialog: (DialogToken) -> Unit = {},
+    onShowSnackbar: (SnackbarToken) -> Unit = {},
     handleException: (Throwable, () -> Unit) -> Unit = { _, _ -> },
 ) {
     Box(
@@ -112,8 +116,8 @@ fun StatisticsScreen(
                         modifier = Modifier.fillMaxSize(),
                         handleException = handleException,
                         onShowDialog = onShowDialog,
+                        onShowSnackbar = onShowSnackbar,
                         navigateToMyInfo = navigateToMyInfo,
-
                     )
                 }
             }

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/my/MyStatisticsContent.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/my/MyStatisticsContent.kt
@@ -126,7 +126,7 @@ fun MyStatisticsContent(
                 spentData = uiState.statistics.recentSpent.toPersistentList(),
                 maximumAmount = uiState.statistics.recentMaximumSpent,
                 totalAmount = uiState.statistics.recentTotalSpent,
-                graphTitle = stringResource(R.string.statistics_recent_8_total_money),
+                graphTitle = stringResource(R.string.statistics_recent_6_total_money),
             )
             Row(
                 modifier = Modifier

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
@@ -44,6 +44,7 @@ import com.susu.core.designsystem.theme.Gray100
 import com.susu.core.designsystem.theme.Gray40
 import com.susu.core.designsystem.theme.SusuTheme
 import com.susu.core.ui.DialogToken
+import com.susu.core.ui.SnackbarToken
 import com.susu.core.ui.extension.collectWithLifecycle
 import com.susu.feature.statistics.R
 import com.susu.feature.statistics.component.RecentSpentGraph
@@ -60,6 +61,7 @@ fun SusuStatisticsRoute(
     viewModel: SusuStatisticsViewModel = hiltViewModel(),
     navigateToMyInfo: () -> Unit,
     onShowDialog: (DialogToken) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -108,6 +110,12 @@ fun SusuStatisticsRoute(
                     dismissText = context.getString(com.susu.core.ui.R.string.word_close),
                     confirmText = context.getString(R.string.statistics_susu_dialog_confirm),
                     onConfirmRequest = navigateToMyInfo,
+                ),
+            )
+
+            SusuStatisticsEffect.ShowNoDataSnackbar -> onShowSnackbar(
+                SnackbarToken(
+                    message = context.getString(R.string.statistics_susu_no_data_snackbar),
                 ),
             )
         }
@@ -261,7 +269,9 @@ fun SusuStatisticsScreen(
         }
 
         PullToRefreshContainer(
-            modifier = Modifier.align(Alignment.TopCenter).offset(y = -(120).dp),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .offset(y = -(120).dp),
             state = refreshState,
             containerColor = Gray10,
         )

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
@@ -210,7 +210,7 @@ fun SusuStatisticsScreen(
 
             RecentSpentGraph(
                 isActive = !uiState.isBlind,
-                graphTitle = stringResource(R.string.statistics_susu_this_year_spent),
+                graphTitle = stringResource(R.string.statistics_recent_6_total_money),
                 spentData = uiState.susuStatistics.recentSpent.toPersistentList(),
                 maximumAmount = uiState.susuStatistics.recentMaximumSpent,
                 totalAmount = uiState.susuStatistics.recentTotalSpent,

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContent.kt
@@ -124,6 +124,7 @@ fun SusuStatisticsRoute(
     LaunchedEffect(key1 = Unit) {
         viewModel.checkAdditionalInfo()
         viewModel.getStatisticsOption()
+        viewModel.initAge()
     }
 
     LaunchedEffect(key1 = uiState.age, key2 = uiState.category, key3 = uiState.relationship) {

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContract.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContract.kt
@@ -12,6 +12,7 @@ import java.util.Date
 
 sealed interface SusuStatisticsEffect : SideEffect {
     data object ShowAdditionalInfoDialog : SusuStatisticsEffect
+    data object ShowNoDataSnackbar : SusuStatisticsEffect
     data class HandleException(val throwable: Throwable, val retry: () -> Unit) : SusuStatisticsEffect
     data class LogAgeOption(val age: StatisticsAge) : SusuStatisticsEffect
     data class LogRelationshipOption(val relationship: String) : SusuStatisticsEffect

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContract.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsContract.kt
@@ -7,6 +7,8 @@ import com.susu.core.ui.base.SideEffect
 import com.susu.core.ui.base.UiState
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
+import java.util.Calendar
+import java.util.Date
 
 sealed interface SusuStatisticsEffect : SideEffect {
     data object ShowAdditionalInfoDialog : SusuStatisticsEffect
@@ -33,3 +35,19 @@ data class SusuStatisticsState(
 enum class StatisticsAge(val num: Int) {
     TEN(10), TWENTY(20), THIRTY(30), FOURTY(40), FIFTY(50), SIXTY(60), SEVENTY(70)
 }
+
+fun Int.toStatisticsAge(): StatisticsAge? {
+    val age = currentYear - this + 1
+    return when {
+        age in 0..19 -> StatisticsAge.TEN
+        age in 20..29 -> StatisticsAge.TWENTY
+        age in 30..39 -> StatisticsAge.THIRTY
+        age in 40..49 -> StatisticsAge.FOURTY
+        age in 50..59 -> StatisticsAge.FIFTY
+        age in 60..69 -> StatisticsAge.SIXTY
+        age >= 70 -> StatisticsAge.SEVENTY
+        else -> null
+    }
+}
+
+val currentYear = Calendar.getInstance().get(Calendar.YEAR)

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsOptionSlot.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsOptionSlot.kt
@@ -43,7 +43,8 @@ fun SusuStatisticsOptionSlot(
     onCategoryClick: () -> Unit = {},
 ) {
     Column(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier
+            .fillMaxWidth()
             .background(color = Gray10, shape = RoundedCornerShape(4.dp))
             .padding(SusuTheme.spacing.spacing_m),
     ) {
@@ -54,7 +55,9 @@ fun SusuStatisticsOptionSlot(
         )
         Spacer(modifier = Modifier.height(SusuTheme.spacing.spacing_xxs))
         Column(
-            modifier = Modifier.fillMaxWidth().background(color = Orange10, shape = RoundedCornerShape(4.dp))
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = Orange10, shape = RoundedCornerShape(4.dp))
                 .padding(horizontal = SusuTheme.spacing.spacing_s, vertical = SusuTheme.spacing.spacing_xxs),
         ) {
             Row(
@@ -82,7 +85,7 @@ fun SusuStatisticsOptionSlot(
             Row(
                 verticalAlignment = Alignment.Bottom,
             ) {
-                if (isBlind) {
+                if (isBlind || money == 0L) {
                     Text(
                         text = stringResource(id = R.string.word_unknown) +
                             stringResource(id = com.susu.core.designsystem.R.string.money_unit),

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsViewModel.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsViewModel.kt
@@ -93,6 +93,11 @@ class SusuStatisticsViewModel @Inject constructor(
                 relationshipId = currentState.relationship.id.toInt(),
                 categoryId = currentState.category.id,
             ).onSuccess {
+
+                if (it.averageSent == 0L) {
+                    postSideEffect(SusuStatisticsEffect.ShowNoDataSnackbar)
+                }
+
                 intent { copy(susuStatistics = it) }
             }.onFailure {
                 postSideEffect(SusuStatisticsEffect.HandleException(it, ::getSusuStatistics))

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsViewModel.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/content/susu/SusuStatisticsViewModel.kt
@@ -7,6 +7,7 @@ import com.susu.core.model.exception.UnknownException
 import com.susu.core.ui.base.BaseViewModel
 import com.susu.domain.usecase.categoryconfig.GetCategoryConfigUseCase
 import com.susu.domain.usecase.envelope.GetRelationShipConfigListUseCase
+import com.susu.domain.usecase.mypage.GetUserUseCase
 import com.susu.domain.usecase.statistics.CheckAdditionalUserInfoUseCase
 import com.susu.domain.usecase.statistics.GetSusuStatisticsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,7 +21,19 @@ class SusuStatisticsViewModel @Inject constructor(
     private val getCategoryConfigUseCase: GetCategoryConfigUseCase,
     private val getRelationShipConfigListUseCase: GetRelationShipConfigListUseCase,
     private val getSusuStatisticsUseCase: GetSusuStatisticsUseCase,
+    private val getUserUseCase: GetUserUseCase,
 ) : BaseViewModel<SusuStatisticsState, SusuStatisticsEffect>(SusuStatisticsState()) {
+
+    fun initAge() {
+        viewModelScope.launch {
+            val userAge = getUserUseCase.invoke().getOrNull()?.birth?.toStatisticsAge() ?: StatisticsAge.TWENTY
+            intent {
+                copy(
+                    age = userAge
+                )
+            }
+        }
+    }
 
     fun checkAdditionalInfo() {
         viewModelScope.launch {

--- a/feature/statistics/src/main/java/com/susu/feature/statistics/navigation/StatisticsNavigation.kt
+++ b/feature/statistics/src/main/java/com/susu/feature/statistics/navigation/StatisticsNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.susu.core.ui.DialogToken
+import com.susu.core.ui.SnackbarToken
 import com.susu.feature.statistics.StatisticsRoute
 
 fun NavController.navigateStatistics(navOptions: NavOptions) {
@@ -17,6 +18,7 @@ fun NavGraphBuilder.statisticsNavGraph(
     navigateToMyInfo: () -> Unit,
     navigateToSent: () -> Unit,
     onShowDialog: (DialogToken) -> Unit,
+    onShowSnackbar: (SnackbarToken) -> Unit,
     handleException: (Throwable, () -> Unit) -> Unit,
 ) {
     composable(route = StatisticsRoute.route) {
@@ -25,6 +27,7 @@ fun NavGraphBuilder.statisticsNavGraph(
             navigateToMyInfo = navigateToMyInfo,
             navigateToSent = navigateToSent,
             onShowDialog = onShowDialog,
+            onShowSnackbar = onShowSnackbar,
             handleException = handleException,
         )
     }

--- a/feature/statistics/src/main/res/values/strings.xml
+++ b/feature/statistics/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
     <string name="statistics_my_dialog_title">아직 볼 수 있는 통계가 없어요</string>
     <string name="statistics_my_dialog_description">작성된 봉투가 있는 경우 통계를 볼 수 있어요!\n정확한 데이터를 위해 약 3분 정도의 시간이 소요될 수 있어요</string>
     <string name="statistics_my_dialog_confirm">봉투 작성하기</string>
+    <string name="statistics_susu_no_data_snackbar">아직 데이터가 충분하지 않아 금액을 표시할 수 없어요</string>
 </resources>

--- a/feature/statistics/src/main/res/values/strings.xml
+++ b/feature/statistics/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="statistics_recent_8_total_money">최근 8개월 간 쓴 금액</string>
+    <string name="statistics_recent_6_total_money">최근 6개월 간 쓴 금액</string>
     <string name="statistics_man_format">%s만원</string>
     <string name="statistics_total_man_prefix">총 </string>
     <string name="statistics_total_man_postfix">만원</string>
@@ -27,7 +27,6 @@
     <string name="statistics_susu_average_title">지금 평균 수수 보기</string>
     <string name="statistics_susu_relationship_average">관계 별 평균 수수</string>
     <string name="statistics_susu_category_average">경조사 카테고리 별 평균 수수</string>
-    <string name="statistics_susu_this_year_spent">올해 쓴 금액</string>
     <string name="statistics_my_dialog_title">아직 볼 수 있는 통계가 없어요</string>
     <string name="statistics_my_dialog_description">작성된 봉투가 있는 경우 통계를 볼 수 있어요!\n정확한 데이터를 위해 약 3분 정도의 시간이 소요될 수 있어요</string>
     <string name="statistics_my_dialog_confirm">봉투 작성하기</string>

--- a/feature/statistics/src/main/res/values/strings.xml
+++ b/feature/statistics/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="word_statistics_to">에</string>
     <string name="word_statistics_send">을 보내고 있어요</string>
     <string name="word_age_unit">%d대</string>
-    <string name="word_age_over_unit">%d대 이상</string>
+    <string name="word_age_over_unit">%d대+</string>
     <string name="word_select_option">옵션 선택</string>
     <string name="statistics_susu_average_title">지금 평균 수수 보기</string>
     <string name="statistics_susu_relationship_average">관계 별 평균 수수</string>


### PR DESCRIPTION
## 💡 Issue
- Resolved: #이슈번호

## 🌱 Key changes
<!--변경사항 적기-->
- 70대 표기를 70대+ 로 변경
- 통계 막대 그래프 정책 변경
    - 연도 관계 없이 최근 6개월 데이터 표시
- [수수 통계] 초기 연령대를 사용자의 나이대로 설정 (일단 코리안 나이로..)
- 데이터 미존재 시, [0원]으로 표기하던 데이터를 [?원]으로 표기 변경 + 스낵바 출력

## ✅ To Reviewers
<!--리뷰에 중점이 될 포인트 요소들 적기-->
<!--다른 개발자들이 참고했으면 하는 사항-->
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|
